### PR TITLE
handle network problems to github at startup

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wiki-plugin-plugmatic",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Federated Wiki - Plugmatic Plugin",
   "keywords": [
     "plugmatic",

--- a/server/server.coffee
+++ b/server/server.coffee
@@ -20,15 +20,17 @@ github = (path, done) ->
       res.setEncoding 'utf8'
       data = ''
       res.on 'error', () ->
-        done "{}"
+        done null
       res.on 'timeout', () ->
-        done "{}"
+        done null
       res.on 'data', (d) ->
         data += d
       res.on 'end', () ->
         done data
+    req.on 'error', () ->
+      done null
   catch e
-    done "{}"
+    done null
 
 # http://www.sebastianseilund.com/nodejs-async-in-practice
 
@@ -40,7 +42,7 @@ startServer = (params) ->
   github '/fedwiki/wiki/master/package.json', (data) ->
     bundle =
       date: Date.now()
-      data: JSON.parse data
+      data: JSON.parse data||'{"dependencies":{}}'
 
   route = (endpoint) -> "/plugin/plugmatic/#{endpoint}"
   path = (file) -> "#{argv.packageDir}/#{file}"

--- a/server/server.coffee
+++ b/server/server.coffee
@@ -15,13 +15,20 @@ github = (path, done) ->
     port: 443
     method: 'GET'
     path: path
-  req = https.get options, (res) ->
-    res.setEncoding 'utf8'
-    data = ''
-    res.on 'data', (d) ->
-      data += d
-    res.on 'end', () ->
-      done data
+  try
+    req = https.get options, (res) ->
+      res.setEncoding 'utf8'
+      data = ''
+      res.on 'error', () ->
+        done "{}"
+      res.on 'timeout', () ->
+        done "{}"
+      res.on 'data', (d) ->
+        data += d
+      res.on 'end', () ->
+        done data
+  catch e
+    done "{}"
 
 # http://www.sebastianseilund.com/nodejs-async-in-practice
 


### PR DESCRIPTION
This is a start on error handling talking to github during server-side plugin startup as suggested by #7. It doesn't seem to be enough. I still get this reported in the server log when starting with my wifi turned off:
```
starting plugin wiki-plugin-rostermatic
caution: ENOENT: no such file or directory, open '/Users/ward/.wiki/localhost/status/plugin/json/tokens.json'

 Error: getaddrinfo ENOTFOUND raw.githubusercontent.com raw.githubusercontent.com:443
    at errnoException (dns.js:28:10)
    at GetAddrInfoReqWrap.onlookup [as oncomplete] (dns.js:76:26)

server unexpectly exitted, 47136 (1)
```