### PR TITLE
Proper Sort Order

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wiki-plugin-plugmatic",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wiki-plugin-plugmatic",
-      "version": "1.5.0",
+      "version": "1.5.1",
       "license": "MIT",
       "dependencies": {
         "async": "^3.2.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wiki-plugin-plugmatic",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Federated Wiki - Plugmatic Plugin",
   "keywords": [
     "plugmatic",

--- a/src/client/browse.js
+++ b/src/client/browse.js
@@ -26,6 +26,7 @@ export function browse(data, $item) {
         if (system.includes(plugin.plugin)) return category == 'system'
         return category == (have || 'option')
       })
+      .toSorted((a,b) => a.plugin.localeCompare(b.plugin))
       .map(format)
       .join('\n')}`,
   )


### PR DESCRIPTION
Proper sort order for Browse All Plugins report.

<img width="508" height="764" alt="image" src="https://github.com/user-attachments/assets/af82b6d7-b4b4-465b-b506-227cde349763" />
